### PR TITLE
Adding Drupal 7 local development settings.

### DIFF
--- a/drupal-7/settings.local.php
+++ b/drupal-7/settings.local.php
@@ -1,0 +1,17 @@
+<?php
+/**
+ * @file
+ * Local development database settings. Great for MAMP, XAMP, etc. in /private.
+ */
+if (!defined('PANTHEON_ENVIRONMENT')) {
+  // Database.
+  $databases['default']['default'] = array(
+    'database' => 'yourlocaldb',
+    'username' => 'root',
+    'password' => 'root',
+    'host' => 'localhost',
+    'driver' => 'mysql',
+    'port' => 3306,
+    'prefix' => '',
+  );
+}


### PR DESCRIPTION
I find this settings file helpful, especially for new developers using Pantheon. I was hoping we could add it to the collection. 