### PR TITLE
don't force caching on multidevs

### DIFF
--- a/drupal-7/settings.cache.php
+++ b/drupal-7/settings.cache.php
@@ -6,8 +6,21 @@
  */
 
 if (defined('PANTHEON_ENVIRONMENT')) {
-  // Drupal caching in development environments.
-  if (!in_array(PANTHEON_ENVIRONMENT, array('test', 'live'))) {
+  // Drupal caching in test and live environments.
+  if (in_array(PANTHEON_ENVIRONMENT, array('test', 'live'))) {
+   // Anonymous caching - enabled.
+    $conf['cache'] = 1;
+    // Block caching - enabled.
+    $conf['block_cache'] = 1;
+    // Expiration of cached pages - 15 minutes.
+    $conf['page_cache_maximum_age'] = 900;
+    // Aggregate and compress CSS files in Drupal - on.
+    $conf['preprocess_css'] = 1;
+    // Aggregate JavaScript files in Drupal - on.
+    $conf['preprocess_js'] = 1;
+  }
+  // Drupal caching in development environments, including multidev
+  else {
     // Anonymous caching.
     $conf['cache'] = 0;
     // Block caching - disabled.
@@ -18,19 +31,6 @@ if (defined('PANTHEON_ENVIRONMENT')) {
     $conf['preprocess_css'] = 0;
     // Aggregate JavaScript files in Drupal - off.
     $conf['preprocess_js'] = 0;
-  }
-  // Drupal caching in test and live environments.
-  else {
-    // Anonymous caching - enabled.
-    $conf['cache'] = 1;
-    // Block caching - enabled.
-    $conf['block_cache'] = 1;
-    // Expiration of cached pages - 15 minutes.
-    $conf['page_cache_maximum_age'] = 900;
-    // Aggregate and compress CSS files in Drupal - on.
-    $conf['preprocess_css'] = 1;
-    // Aggregate JavaScript files in Drupal - on.
-    $conf['preprocess_js'] = 1;
   }
   // Minimum cache lifetime - always none.
   $conf['cache_lifetime'] = 0;


### PR DESCRIPTION
else statement would catch all multidevs. As the name states, these are dev environments and we should not force the same caches settings upon it as we do for LIVE.